### PR TITLE
Correctly process nested keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,25 @@ export default (engine, whitelist = []) => {
         load() {
             return engine.load().then((result) => {
                 whitelist.forEach((key) => {
-                    result[key] = fromJS(result[key]);
+                    // Support strings for one-level paths
+                    if (typeof key === 'string') {
+                        result[key] = fromJS(result[key]);  // eslint-disable-line no-param-reassign
+                        return;
+                    }
+
+                    let loadState = result || {};
+                    const keyFound = key.slice(0, key.length - 1).every((keyPart) => {
+                        if (!loadState.hasOwnProperty(keyPart)) {
+                            return false;
+                        }
+                        loadState = loadState[keyPart];
+                        return true;
+                    });
+
+                    const lastKeyPart = key[key.length - 1];
+                    if (keyFound && loadState.hasOwnProperty(lastKeyPart)) {
+                        loadState[lastKeyPart] = fromJS(loadState[lastKeyPart]);
+                    }
                 });
                 return result;
             });


### PR DESCRIPTION
In the example in the documentation, it is suggested that nested keys (in the form of an array making up a key path) will be processed in a similar fashion to `redux-storage-decorator-filter` but that's not actually implemented.

This PR implemented this behaviour (not necessarily in the most compact way).

This also means that `redux-storage-merger-immutablejs` will generate warnings on the merge, but that can be fixed relatively easily so I can submit a PR for that as well.
